### PR TITLE
使用GitHub Action自动打包crx扩展，并利用GitHub进行自动更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: buildCrx
+on:
+  watch:
+    types: [started]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: stable #只打包stable分支
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '11.x'
+      - name: build
+        env:
+          PRIVATE_KEY: ${{ secrets.buildPem }}
+        run: |
+          npm install
+          npm install crx3
+          cat <<< $PRIVATE_KEY > ../build.pem
+          npm run crx
+      - name: Set git identity
+        run : |
+          git config --global user.email "tofuliang@gmail.com"
+          git config --global user.name "tofuliang"
+          rm -fr node_modules output package-lock.json
+          git add chrome/fehelper.crx chrome/update.xml
+          git checkout *
+          git commit -m "update crx"
+          git push

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,7 @@ let watchPath = require('gulp-watch-path');
 let gcallback = require('gulp-callback');
 
 gulp.task('clean', () => {
-    return gulp.src('output', {read: false}).pipe(clean({force: true}));
+    return gulp.src(['output','chrome'], {read: false}).pipe(clean({force: true}));
 });
 
 gulp.task('copy', () => {
@@ -155,6 +155,24 @@ gulp.task('zip', () => {
 
 });
 
+// 打包成crx
+gulp.task('_crx',() => {
+    let pathOfMF = './output/apps/manifest.json';
+    let manifest = require(pathOfMF);
+    shell.exec('[ ! -d chrome ] && mkdir chrome');
+    shell.exec('cat output/fehelper.zip | npx crx3 -p ../build.pem -o chrome/fehelper.crx -x chrome/update.xml --appVersion '+manifest.version+' --crxURL https://raw.githubusercontent.com/'+manifest.author+'/FeHelper/master/fehelper.crx');
+
+    let size = fs.statSync('chrome/fehelper.crx').size;
+    size = pretty(size);
+
+    console.log('\n\nfehelper.crx 已打包完成！');
+    console.log('\n\n================================================================================');
+    console.log('    当前版本：', manifest.version, '\t文件大小:', size);
+    console.log('    提交到GitHub享受摆脱Chrome Webstore的自动更新吧');
+    console.log('================================================================================\n\n');
+
+});
+
 // 打包Firefox安装包
 gulp.task('firefox', () => {
     shell.exec('rm -rf output-firefox && cp -r output output-firefox && rm -rf output-firefox/fehelper.zip');
@@ -200,6 +218,10 @@ gulp.task('firefox', () => {
 // builder
 gulp.task('default', ['clean'], () => {
     runSequence(['copy', 'css', 'js', 'html', 'json'], 'zip');
+});
+
+gulp.task('crx', ['clean'], () => {
+    runSequence(['copy', 'css', 'js', 'html', 'json'],'zip','_crx');
 });
 
 gulp.task('sync', () => {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "scripts": {
     "watch": "gulp watch",
-    "build": "gulp"
+    "build": "gulp",
+    "crx": "gulp crx"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`GitHub Action`只打包 `stable`分支，参见`.github/workflows/build.yml` 第 11 行。
打包crx用到的证书，以`buildPem`为key,证书内容文本为value 存放在仓库的 `Secrets`中。
使用此自动更新方法需要添加白名单，扩展ID可以在`chrome/update.xml`中找到。

目前的自动打包触发方式是自己star一下项目，再次触发的话，取消star,再次star就可以。当然也可以修改`.github/workflows/build.yml`的2~10行。