### PR TITLE
base64编码优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules/
 package-lock.json
 output/apps/
 output-firefox/
+
+*.crx
+*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@ node_modules/
 package-lock.json
 output/apps/
 output-firefox/
-
-*.crx
-*.pem

--- a/apps/image-base64/index.css
+++ b/apps/image-base64/index.css
@@ -116,3 +116,9 @@ form {display: none}
     color:#f00;
     border-bottom: 1px solid #f00;
 }
+
+.x-error {
+   margin: 0px 0px 10px 0px;
+   padding-bottom: 10px;
+   color:#f00;
+}

--- a/apps/image-base64/index.html
+++ b/apps/image-base64/index.html
@@ -1,1 +1,84 @@
-<!DOCTYPE HTML><html lang="zh-CN">    <head>        <title>图片Base64工具（DataURI数据）</title>        <meta charset="UTF-8">        <link rel="stylesheet" href="index.css" />        <script type="text/javascript" src="../static/vendor/vue/vue.js"></script>        <script src="../static/vendor/require/require.js"></script>    </head>    <body>        <div class="wrapper" id="pageContainer">            <div class="panel panel-default" style="margin-bottom: 0px;">                <div class="panel-heading">                    <h3 class="panel-title">                        <a href="http://www.baidufe.com/fehelper/feedback.html" target="_blank" class="x-a-high">                            <img src="../static/img/fe-16.png" alt="fehelper"/> FeHelper                        </a>：{{ toolName[curType] }}                        <span class="x-switch ui-fl-r" ref="btnSwitch" @click="trans">切换为{{toolName[nextType]}}&gt;&gt;</span>                    </h3>                </div>            </div>            <div class="panel-body mod-imagebase64" ref="imageBase64" v-show="curType=='image'">                <div class="row">                  <table>                      <tr>                          <td>                            <div class="x-panel" ref="panelBox">                              <img id="preview" alt="" :src="previewSrc" v-show="!!previewSrc.length">                              <div class="x-tips">                                  <a id="upload" href="#" ref="uploadBox" @click="upload($event)">选择图片</a><br>                                  或者选择一张图片拖拽图片到这里来                              </div>                            </div>                              <div class="tips">                                  1、支持<i>屏幕截图</i>后直接在此处粘贴进行转化<br/>2、支持<i>复制文件、复制图片</i>在线地址在此处直接粘贴进行转化                              </div>                          </td>                          <td>                              <textarea id="base64Result" title="点击自动选择" placeholder="内容会自动生成..." readonly ref="resultBox" @click="select()" v-model="resultContent" class="form-control"></textarea>                              <div class="x-result-info">                                  <div class="x-item">                                      <span class="x-title">原始图片大小：</span><span id="sizeOri">{{sizeOri}}</span>                                  </div>                                  <div class="x-item">                                      <span class="x-title">DataUri&nbsp;&nbsp;大小：</span><span id="sizeBase">{{sizeBase}}</span>                                  </div>                              </div>                          </td>                      </tr>                  </table>                  <form action="#">                      <input type="file" id="file" accept=".jpg,.jpeg,.gif,.png,.bmp" ref="fileBox" @change="convert()">                  </form>                  <img id="img" alt="">                </div>            </div>            <div class="panel-body mod-base64image" ref="base64Image" v-show="curType=='base64'">                <div class="row">                    <table>                        <tr>                            <td>                                <textarea id="base64Input" class="form-control" title="点击自动选择" placeholder="在这里粘贴DataURI数据..." v-model="txtBase64Input"></textarea>                            </td>                            <td>                                <div class="x-panel">                                    <img id="base64Image" alt="" :src="txtBase64Input" v-show="!!txtBase64Input.length" @error="loadError">                                </div>                            </td>                        </tr>                    </table>                </div>            </div>        </div>        <script type="text/javascript" src="index.js"></script>    </body></html>
+<!DOCTYPE HTML>
+<html lang="zh-CN">
+    <head>
+        <title>图片Base64工具（DataURI数据）</title>
+        <meta charset="UTF-8">
+        <link rel="stylesheet" href="index.css" />
+        <script type="text/javascript" src="../static/vendor/vue/vue.js"></script>
+        <script src="../static/vendor/require/require.js"></script>
+    </head>
+    <body>
+        <div class="wrapper" id="pageContainer">
+            <div class="panel panel-default" style="margin-bottom: 0px;">
+                <div class="panel-heading">
+                    <h3 class="panel-title">
+                        <a href="http://www.baidufe.com/fehelper/feedback.html" target="_blank" class="x-a-high">
+                            <img src="../static/img/fe-16.png" alt="fehelper"/> FeHelper
+                        </a>：{{ toolName[curType] }}
+
+                        <span class="x-switch ui-fl-r" ref="btnSwitch" @click="trans">切换为{{toolName[nextType]}}&gt;&gt;</span>
+                    </h3>
+                </div>
+            </div>
+            <div class="panel-body mod-imagebase64" ref="imageBase64" v-show="curType=='image'">
+                <div class="row">
+                  <table>
+                      <tr>
+                          <td>
+                            <div class="x-panel" ref="panelBox">
+                              <img id="preview" alt="" :src="previewSrc" v-show="!!previewSrc.length">
+                              <div class="x-tips">
+                                  <a id="upload" href="#" ref="uploadBox" @click="upload($event)">选择图片</a><br>
+                                  或者选择一张图片拖拽图片到这里来
+                              </div>
+                            </div>
+
+                              <div class="tips">
+                                  1、支持<i>屏幕截图</i>后直接在此处粘贴进行转化<br/>2、支持<i>复制文件、复制图片</i>在线地址在此处直接粘贴进行转化
+                              </div>
+                          </td>
+                          <td>
+                              <textarea id="base64Result" title="点击自动选择" placeholder="内容会自动生成..." readonly ref="resultBox" @click="select()" v-model="resultContent" class="form-control"></textarea>
+                              <div class="x-result-info">
+                                  <div class="x-item">
+                                      <span class="x-title">原始图片大小：</span><span id="sizeOri">{{sizeOri}}</span>
+                                  </div>
+                                  <div class="x-item">
+                                      <span class="x-title">DataUri&nbsp;&nbsp;大小：</span><span id="sizeBase">{{sizeBase}}</span>
+                                  </div>
+                              </div>
+                          </td>
+                      </tr>
+                  </table>
+                  <form action="#">
+                      <input type="file" id="file" accept=".jpg,.jpeg,.gif,.png,.bmp" ref="fileBox" @change="convert()">
+                  </form>
+                  <img id="img" alt="">
+                </div>
+            </div>
+
+            <div class="panel-body mod-base64image" ref="base64Image" v-show="curType=='base64'">
+                <div class="row">
+                    <table>
+                        <tr>
+                            <td>
+                                <textarea id="base64Input" class="form-control" title="点击自动选择" placeholder="在这里粘贴DataURI数据..." v-model="txtBase64Input"></textarea>
+                            </td>
+                            <td>
+                                <div class="x-panel">
+                                    <img id="base64Image" style="width:100%;height:100%;" alt="" :src="txtBase64Output" v-show="!!txtBase64Input.length" @error="loadError">
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        
+
+        <div v-show="!!error.length" class="x-error">{{ error }}</div>
+        </div>
+
+
+        <script type="text/javascript" src="index.js"></script>
+    </body>
+</html>

--- a/apps/image-base64/index.js
+++ b/apps/image-base64/index.js
@@ -200,10 +200,6 @@ new Vue({
             }
         },
 
-        format:function(){
-            return this.txtBase64Output
-        },
-
         trans: function () {
             this.curType = {image: 'base64', base64: 'image'}[this.curType];
             this.nextType = {image: 'base64', base64: 'image'}[this.nextType];

--- a/apps/image-base64/index.js
+++ b/apps/image-base64/index.js
@@ -11,8 +11,27 @@ new Vue({
         toolName: {'image': '图片转Base64', 'base64': 'Base64转图片'},
         curType: 'image',
         nextType: 'base64',
-        txtBase64Input: ''
+        txtBase64Input: '',
+        txtBase64Output: '',
+        error:''
     },
+
+    watch: {
+        txtBase64Input:{
+            immediate: true,
+            handler(newVal, oldVal) {
+                this.error = ''   
+                this.txtBase64Output = ''
+                if(newVal.length === 0) return
+                if(newVal.indexOf("data:") === -1) {
+                    this.txtBase64Output = "data:image/jpeg;base64,"+newVal
+                } else {
+                    this.txtBase64Output = newVal
+                }
+            },
+        }
+    },
+
     mounted: function () {
 
         let MSG_TYPE = Tarp.require('../static/js/msg_type');
@@ -181,6 +200,10 @@ new Vue({
             }
         },
 
+        format:function(){
+            return this.txtBase64Output
+        },
+
         trans: function () {
             this.curType = {image: 'base64', base64: 'image'}[this.curType];
             this.nextType = {image: 'base64', base64: 'image'}[this.nextType];
@@ -188,7 +211,7 @@ new Vue({
 
         loadError: function (e) {
             if(this.curType === 'base64' && this.txtBase64Input.trim().length) {
-                alert('无法识别的Base64编码，请确认是正确的图片Data URI？');
+                this.error ='无法识别的Base64编码，请确认是正确的图片Data URI？';
             }
         }
     }


### PR DESCRIPTION
1.去掉输入编码弹出alter，改为页面显示错误，改写数据方便
2.当输入图片base64时，如果不带"data:image/jpeg;base64,"前缀时，自动添加