### PR TITLE
fix(chatgpt): 解决返回图片展示时无法完整显示的问题

### DIFF
--- a/apps/chatgpt/index.js
+++ b/apps/chatgpt/index.js
@@ -153,12 +153,15 @@ new Vue({
             });
         },
         drawImage(message){
+            let imgSize = this.imgSize || '512x512'
+
             this.chatWithOpenAI({
                 url:'https://api.openai.com/v1/images/generations',
-                data: {prompt:message,n:1,size: this.imgSize || '512x512'},
+                data: {prompt:message,n:1,size: imgSize},
                 buildResponse: json => {
                     return this.imageBase64(json.data[0].url).then(dataURI => {
-                        return `<img src="${dataURI}" alt="图片" class="gpt-image" />`;
+                        let [width, height] = imgSize.split('x')
+                        return `<img src="${dataURI}" alt="图片" class="gpt-image" width="${width}px" height="${height}px" />`;
                     });
                 }
             });


### PR DESCRIPTION
通过已知的图片大小，固定图片尺寸，无需等加载后再执行滚动到底。