### PR TITLE
fix(json-format): 修复 JSON 格式化后的 value 中空白字符显示缺失的问题

### DIFF
--- a/apps/json-format/content-script.css
+++ b/apps/json-format/content-script.css
@@ -93,8 +93,10 @@ html.fh-jf .item .kv-list {
     border-left: 1px dashed #bbb;
     margin-left: 2px
 }
+
 html.fh-jf .item .string {
-    word-wrap: break-word
+    word-wrap: break-word;
+    white-space: pre-wrap;
 }
 
 html.fh-jf .item .string a {


### PR DESCRIPTION
修复 JSON 格式化后的 value 中空白字符显示缺失的问题

相关 Issue：https://github.com/zxlie/FeHelper/issues/409