### PR TITLE
修复Json美化工具，原始 JSON 中包含嵌套 JSON 时整数精度丢失问题

### DIFF
--- a/apps/json-format/index.js
+++ b/apps/json-format/index.js
@@ -847,7 +847,16 @@ function parseWithBigInt(text) {
     const keyFixRegex = /([\{,]\s*)(\w+)(\s*:)/g;
     fixed = fixed.replace(keyFixRegex, '$1"$2"$3');
     // 标记 16 位及以上的整数（允许值后有空白，再跟 , ] } 或结尾）
-    fixed = fixed.replace(/([:,\[]\s*)(-?\d{16,})(\s*)(?=(?:,|\]|\}|$))/g, function(m, p1, num, sp) {
+    // 使用 offset 检查匹配位置是否在 JSON 字符串内部，避免破坏嵌套转义的 JSON 字符串
+    fixed = fixed.replace(/([:,\[]\s*)(-?\d{16,})(\s*)(?=(?:,|\]|\}|$))/g, function(m, p1, num, sp, offset) {
+        let inStr = false;
+        let esc = false;
+        for (let i = 0; i < offset; i++) {
+            if (esc) { esc = false; continue; }
+            if (fixed[i] === '\\') { esc = true; continue; }
+            if (fixed[i] === '"') { inStr = !inStr; }
+        }
+        if (inStr) return m;
         return p1 + '"__BigInt__' + num + '"' + sp;
     });
     return JSON.parse(fixed, function(key, value) {


### PR DESCRIPTION
修复前：
<img width="1301" height="446" alt="Clipboard_Screenshot_1772791163" src="https://github.com/user-attachments/assets/cf0f1835-a446-4ce3-90b4-c13a90b459da" />


修复后：
<img width="1287" height="359" alt="Clipboard_Screenshot_1772790586" src="https://github.com/user-attachments/assets/fb6587db-6c7d-477c-8231-53eb6b0ce8b7" />

```JSON
{
  "body":{
    "data":{
      "account_id":1401004938049356981
    }
  },
  "rawBody":"{\"data\":{\"account_id\":1401004938049356981}"
}
```